### PR TITLE
(feature): Whitelist http verbs

### DIFF
--- a/lib/spryte/rspec/macros.rb
+++ b/lib/spryte/rspec/macros.rb
@@ -2,6 +2,8 @@ module Spryte
   module RSpec
     module Macros
 
+      class InvalidHTTPVerb < StandardError; end
+
       def host(domain)
         before(:each) { self.host = domain }
       end
@@ -25,6 +27,7 @@ module Spryte
       end
 
       def method(verb)
+        raise InvalidHTTPVerb, invalid_http_verb_message(verb) unless valid_http_verb?(verb)
         let(:method) { verb.to_sym }
       end
 
@@ -44,6 +47,31 @@ module Spryte
         end
       end
 
+      private def valid_http_verb?(verb)
+        VALID_HTTP_VERBS.include?(verb)
+      end
+
+      private def invalid_http_verb_message(verb)
+        "#{verb} is not a valid http verb.\nValid verbs are:\n#{VALID_HTTP_VERBS.map(&:inspect).join("\n")}"
+      end
+
+      VALID_HTTP_VERBS = [
+        :get,
+        :head,
+        :post,
+        :patch,
+        :put,
+        :proppatch,
+        :lock,
+        :unlock,
+        :options,
+        :propfind,
+        :delete,
+        :move,
+        :copy,
+        :mkcol,
+        :trace,
+      ]
     end
   end
 end


### PR DESCRIPTION
The 'method' method should only accept http verbs.
https://github.com/rspec/rspec-core/issues/2008 was such a tricky one to
debug, in part because this method accepts anything which can be coerced
into a symbol.

The list of verbs here is based on the methods available to
Net::HTTP in the Ruby standard library.
