### PR TITLE
Deprecate macro `#method` in favour of `#through`

### DIFF
--- a/lib/spryte/rspec/macros.rb
+++ b/lib/spryte/rspec/macros.rb
@@ -26,9 +26,15 @@ module Spryte
         }
       end
 
-      def method(verb)
+      def through(verb)
         raise InvalidHTTPVerb, invalid_http_verb_message(verb) unless valid_http_verb?(verb)
-        let(:method) { verb.to_sym }
+        let(:through) { verb.to_sym }
+        let(:method) { through }
+      end
+
+      def method(verb)
+        warn "#{ Kernel.caller.first }: `#method' is deprecated due to a collision with Object#method in ruby core, please use `#through' instead."
+        through(verb)
       end
 
       def path(name)

--- a/spec/spryte/rspec_spec.rb
+++ b/spec/spryte/rspec_spec.rb
@@ -1,0 +1,50 @@
+require "spryte/rspec"
+
+class RSpecContextMock
+  include Spryte::RSpec::Macros
+  def let(*args)
+  end
+end
+
+RSpec.describe Spryte::RSpec do
+
+  describe Spryte::RSpec::Macros do
+
+    subject(:rspec) { RSpecContextMock.new }
+
+    shared_examples "setting http method verbs for rspec request specs" do |method_name|
+      it "sets the right let variables" do
+        disable_output do
+          expect(rspec).to receive(:let).with(:method).once
+          expect(rspec).to receive(:let).with(:through).once
+          rspec.public_send(method_name, Spryte::RSpec::Macros::VALID_HTTP_VERBS.sample)
+        end
+      end
+      it "raise exception when using an incorrect http verb" do
+        disable_output do
+          expect { rspec.public_send(method_name, :poo) }.to raise_exception(Spryte::RSpec::Macros::InvalidHTTPVerb)
+        end
+      end
+    end
+
+    describe "#method" do
+      it_behaves_like "setting http method verbs for rspec request specs", :method
+      it "shows a deprecation warning pointing to using #through" do
+        expect { rspec.method(:get) }.to output(/#through/).to_stderr
+      end
+      context "when the major version of spryte is greater than 0" do
+        it "does not respond to #method since it was deprecated" do
+          if Integer(Spryte::MAJOR) > 0
+            expect(Spryte::RSpec::Macros.instance_methods).to_not include :method
+          end
+        end
+      end
+    end
+
+    describe "#through" do
+      it_behaves_like "setting http method verbs for rspec request specs", :through
+    end
+
+  end
+
+end


### PR DESCRIPTION
As explained in #1 by @dgmstuart, the `#method` in spryte has a nameclash with `Object#method`.

Chose to name it to `#through` rather than `#http_method` or `#verb` since it's a semantically intuitive DSL.

Made sure that we output a deprecation warning pointing users to the new method and that the test suite will fail once we upgrade major version without removing the deprecated method.
