### PR TITLE
Fix/other reference to method

### DIFF
--- a/lib/spryte/rspec/macros.rb
+++ b/lib/spryte/rspec/macros.rb
@@ -12,7 +12,8 @@ module Spryte
 
         host ENV.fetch("SPRYTE_RSPEC_HOST", "localhost")
 
-        let(:method) { :get }
+        let(:through) { :get }
+        let(:method) { method(:get) }
         let(:path) { "/" }
         let(:params) { Hash[] }
         let(:headers) { {
@@ -21,8 +22,8 @@ module Spryte
         } }
 
         subject(name) {
-          parameters = [ :get ].include?(method) ? params : params.to_json
-          send method, path.to_s, parameters, headers
+          parameters = [ :get ].include?(through) ? params : params.to_json
+          send through, path.to_s, parameters, headers
         }
       end
 

--- a/lib/spryte/rspec/macros.rb
+++ b/lib/spryte/rspec/macros.rb
@@ -12,8 +12,7 @@ module Spryte
 
         host ENV.fetch("SPRYTE_RSPEC_HOST", "localhost")
 
-        let(:through) { :get }
-        let(:method) { method(:get) }
+        through(:get)
         let(:path) { "/" }
         let(:params) { Hash[] }
         let(:headers) { {
@@ -30,12 +29,19 @@ module Spryte
       def through(verb)
         raise InvalidHTTPVerb, invalid_http_verb_message(verb) unless valid_http_verb?(verb)
         let(:through) { verb.to_sym }
-        let(:method) { through }
+        let(:method) {
+          __deprecation_warning
+          through
+        }
       end
 
       def method(verb)
-        warn "#{ Kernel.caller.first }: `#method' is deprecated due to a collision with Object#method in ruby core, please use `#through' instead."
+        __deprecation_warning
         through(verb)
+      end
+
+      def __deprecation_warning
+        warn "#{ Kernel.caller.first }: `#method' is deprecated due to a collision with Object#method in ruby core, please use `#through' instead."
       end
 
       def path(name)

--- a/lib/spryte/rspec/macros.rb
+++ b/lib/spryte/rspec/macros.rb
@@ -35,11 +35,6 @@ module Spryte
         }
       end
 
-      def method(verb)
-        __deprecation_warning
-        through(verb)
-      end
-
       def __deprecation_warning
         warn "#{ Kernel.caller.first }: `#method' is deprecated due to a collision with Object#method in ruby core, please use `#through' instead."
       end

--- a/spec/spryte/rspec_spec.rb
+++ b/spec/spryte/rspec_spec.rb
@@ -2,8 +2,9 @@ require "spryte/rspec"
 
 class RSpecContextMock
   include Spryte::RSpec::Macros
-  def let(*args)
-  end
+  def let(*args); end
+  def before(*args); end
+  def subject(*args); end
 end
 
 RSpec.describe Spryte::RSpec do
@@ -43,6 +44,20 @@ RSpec.describe Spryte::RSpec do
 
     describe "#through" do
       it_behaves_like "setting http method verbs for rspec request specs", :through
+    end
+
+    describe "#request" do
+      it "sets the right let variables" do
+        disable_output do
+          aggregate_failures do
+            expect(rspec).to receive(:let).with(:path).once
+            expect(rspec).to receive(:let).with(:params).once
+            expect(rspec).to receive(:let).with(:headers).once
+            expect(rspec).to receive(:let).with(:method).once
+            rspec.request(:my_awesome_request)
+          end
+        end
+      end
     end
 
   end

--- a/spec/spryte/rspec_spec.rb
+++ b/spec/spryte/rspec_spec.rb
@@ -28,20 +28,6 @@ RSpec.describe Spryte::RSpec do
       end
     end
 
-    describe "#method" do
-      it_behaves_like "setting http method verbs for rspec request specs", :method
-      it "shows a deprecation warning pointing to using #through" do
-        expect { rspec.method(:get) }.to output(/#through/).to_stderr
-      end
-      context "when the major version of spryte is greater than 0" do
-        it "does not respond to #method since it was deprecated" do
-          if Integer(Spryte::MAJOR) > 0
-            expect(Spryte::RSpec::Macros.instance_methods).to_not include :method
-          end
-        end
-      end
-    end
-
     describe "#through" do
       it_behaves_like "setting http method verbs for rspec request specs", :through
     end

--- a/spec/spryte/rspec_spec.rb
+++ b/spec/spryte/rspec_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe Spryte::RSpec do
             expect(rspec).to receive(:let).with(:params).once
             expect(rspec).to receive(:let).with(:headers).once
             expect(rspec).to receive(:let).with(:method).once
+            expect(rspec).to receive(:let).with(:through).once
             rspec.request(:my_awesome_request)
           end
         end


### PR DESCRIPTION
Set `through` in #request - otherwise specs which use `through` and not `method` will fail with
"Invalid http verb", and raise deprecation warnings.

Fixes #4

I haven't been able to test nearly as much of this as I'd like - not sure it's really possible to e.g. check that if you try and _use_ `method` (as assigned by let) then you get a deprecation warning.
